### PR TITLE
Add props to navbar test

### DIFF
--- a/src/components/Mynavbar1/__test__/Mynavbar1.test.js
+++ b/src/components/Mynavbar1/__test__/Mynavbar1.test.js
@@ -5,5 +5,5 @@ import '@testing-library/jest-dom';
 
 it('renders without crashing', () => {
   const div = document.createElement('div');
-  render(<Mynavbar1 />, div);
+  render(<Mynavbar1 searchButton={() => void 0} userLocation={""} />, div);
 });


### PR DESCRIPTION
**Notes**

- Navbar tests are failing because its props are undefined (i.e. no props are being passed in, searchButton and userLocation)
- Added some dummy values to the required props